### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Protobuf format is based on this [open pull request](https://github.com/JemD
 Run-able code samples are available in the `/samples` folder.
 
 ### Setup
-Install Bazel. Instuctions found in (Bazel documentation)(https://docs.bazel.build/versions/master/install-ubuntu.html).
+Install Bazel. Instuctions found in [Bazel documentation](https://docs.bazel.build/versions/master/install-ubuntu.html).
 
 ### Run
 1. Create executable <br/>


### PR DESCRIPTION
Make "Bazel documentation" render as a link.

Previously was in parentheses followed by the link.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR